### PR TITLE
Added Test Smell Detector plugin to pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,27 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 
+	<repositories>
+		<repository>
+			<id>jitpack.io</id>
+			<url>https://jitpack.io</url>
+		</repository>
+	</repositories>
+
+	<pluginRepositories>
+		<pluginRepository>
+			<id>jitpack.io</id>
+			<url>https://jitpack.io</url>
+		</pluginRepository>
+	</pluginRepositories>
+
 	<dependencies>
+		<dependency>
+			<groupId>com.github.OhhTuRnz</groupId>
+			<artifactId>TestSmellDetectorPlugin</artifactId>
+			<version>1.0</version>
+		</dependency>
+
 		<!-- https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-api -->
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
@@ -48,6 +68,20 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>2.22.0</version>
+			</plugin>
+
+			<plugin>
+				<groupId>com.github.OhhTuRnz</groupId>
+				<artifactId>TestSmellDetectorPlugin</artifactId>
+				<version>1.0</version>
+				<executions>
+					<execution>
+						<phase>test</phase>
+						<goals>
+							<goal>detect</goal>
+						</goals>
+					</execution>
+				</executions>
 			</plugin>
 
 		</plugins>


### PR DESCRIPTION
Añade al fichero "pom.xml" la dependencia al plugin Maven que detecta Test Smells en el proyecto, enlazándolo con la fase test.

El fichero JAR del plugin se descarga del siguiente repositorio de jitpack.io:

> OhhTuRnz/TestSmellDetectorPlugin

y puede ejecutarse con el comando:

> mvn test

Autor: Alejando Carrasco Aragón (Grupo C).